### PR TITLE
Switch to openjdk for java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk11
+  - openjdk11
 node_js: "11.5"
 
 addons:


### PR DESCRIPTION
Because of licensing issues, openjdk is prefered for java 11.

Also some travis-ci jobs for oraclejdk11 failed at installation, so this should fix that aswell.