### PR TITLE
Add hooks to build image on dockerhub

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,17 @@
+#!/bin/bash
+echo "=> Building the frontend"
+docker run \
+  -v $(pwd)/frontend:/src \
+  -w /src \
+  node:11 \
+  /bin/sh -c 'npm install && $(npm bin)/ng build --prod'
+
+echo "=> Building the backend"
+docker run  \
+  -v $(pwd)/backend:/src \
+  -w /src \
+  java:8 \
+  ./mvnw install -DskipTests
+
+echo "=> Building the docker image"
+docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
This allows us to use docker hub's automated builds to create up-to-date MAYPAD docker container in an CI/CD-pipeline whenever PRs get merged into master.