### PR TITLE
Exclude id from equals and hash methods

### DIFF
--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/Project.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/Project.java
@@ -4,6 +4,7 @@ import de.fraunhofer.iosb.maypadbackend.model.repository.Repository;
 import de.fraunhofer.iosb.maypadbackend.model.serviceaccount.ServiceAccount;
 import de.fraunhofer.iosb.maypadbackend.model.webhook.InternalWebhook;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Basic;
@@ -32,6 +33,7 @@ import java.util.Date;
 public class Project {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/Projectgroup.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/Projectgroup.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.iosb.maypadbackend.model;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.CascadeType;
@@ -29,6 +30,7 @@ import java.util.List;
 public class Projectgroup {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/build/Build.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/build/Build.java
@@ -3,6 +3,7 @@ package de.fraunhofer.iosb.maypadbackend.model.build;
 import de.fraunhofer.iosb.maypadbackend.model.Status;
 import de.fraunhofer.iosb.maypadbackend.model.repository.Commit;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.CascadeType;
@@ -30,6 +31,7 @@ import java.util.Date;
 public class Build {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/build/BuildType.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/build/BuildType.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.iosb.maypadbackend.model.build;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -19,6 +20,7 @@ import javax.persistence.Id;
 public abstract class BuildType {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/deployment/Deployment.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/deployment/Deployment.java
@@ -2,6 +2,7 @@ package de.fraunhofer.iosb.maypadbackend.model.deployment;
 
 import de.fraunhofer.iosb.maypadbackend.model.build.Build;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.CascadeType;
@@ -27,6 +28,7 @@ import java.util.Date;
 public class Deployment {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/deployment/DeploymentType.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/deployment/DeploymentType.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.iosb.maypadbackend.model.deployment;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -22,6 +23,7 @@ import javax.persistence.InheritanceType;
 public abstract class DeploymentType {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/person/Mail.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/person/Mail.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.iosb.maypadbackend.model.person;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
@@ -21,6 +22,7 @@ import javax.persistence.Id;
 public class Mail {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/person/Person.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/person/Person.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.iosb.maypadbackend.model.person;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
@@ -24,6 +25,7 @@ import javax.persistence.InheritanceType;
 public class Person {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/repository/Branch.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/repository/Branch.java
@@ -9,6 +9,7 @@ import de.fraunhofer.iosb.maypadbackend.model.person.Mail;
 import de.fraunhofer.iosb.maypadbackend.model.person.Person;
 import de.fraunhofer.iosb.maypadbackend.model.webhook.InternalWebhook;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -36,6 +37,7 @@ import java.util.List;
 public class Branch {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/repository/Commit.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/repository/Commit.java
@@ -2,6 +2,7 @@ package de.fraunhofer.iosb.maypadbackend.model.repository;
 
 import de.fraunhofer.iosb.maypadbackend.model.person.Author;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.CascadeType;
@@ -27,6 +28,7 @@ import java.util.Date;
 public class Commit {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/repository/DependencyDescriptor.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/repository/DependencyDescriptor.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.iosb.maypadbackend.model.repository;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import javax.persistence.Basic;
 import javax.persistence.Column;
@@ -14,6 +15,7 @@ import javax.persistence.Id;
 public class DependencyDescriptor {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/repository/Repository.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/repository/Repository.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.iosb.maypadbackend.model.repository;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.CascadeType;
@@ -30,6 +31,7 @@ import java.util.Map;
 public class Repository {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/repository/Tag.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/repository/Tag.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.iosb.maypadbackend.model.repository;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -21,6 +22,7 @@ import javax.persistence.OneToOne;
 public class Tag {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/serviceaccount/ServiceAccount.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/serviceaccount/ServiceAccount.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.iosb.maypadbackend.model.serviceaccount;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -22,6 +23,7 @@ import javax.persistence.InheritanceType;
 public abstract class ServiceAccount {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/webhook/Webhook.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/webhook/Webhook.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.iosb.maypadbackend.model.webhook;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
@@ -24,6 +25,7 @@ import javax.persistence.InheritanceType;
 public abstract class Webhook {
 
     @Id
+    @EqualsAndHashCode.Exclude
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
     private int id;


### PR DESCRIPTION
This PR fixes the equals and hash methods in the model by excluding the id.