### PR TITLE
Return HttpStatusCode when calling success/failure webhook

### DIFF
--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/controller/WebhookController.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/controller/WebhookController.java
@@ -4,6 +4,8 @@ import de.fraunhofer.iosb.maypadbackend.services.webhook.WebhookService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,10 +36,12 @@ public class WebhookController {
      * Handle a called webhook.
      *
      * @param token Webhook token
+     * @return ResponseEntity with StatusCode
      */
     @GetMapping("/{token}")
-    public void handleWebhook(@PathVariable String token) {
+    public ResponseEntity handleWebhook(@PathVariable String token) {
         webhookService.handle(token);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
 


### PR DESCRIPTION
With this PR webhook calls will return a useful HTTP status code. Other than the status code, the page will be empty.