### PR TITLE
Adjust priorities for status

### DIFF
--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/Projectgroup.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/Projectgroup.java
@@ -73,7 +73,10 @@ public class Projectgroup {
     public Status updateStatus() {
         if (projects != null) {
             projects.forEach(Project::updateStatus);
-            Optional<Project> maxPrioProject = projects.stream().max(Comparator.comparing(p -> p.getBuildStatus().getPriority()));
+            Optional<Project> maxPrioProject = projects.stream().max(Comparator.comparing(p -> {
+                int currentPriority = p.getBuildStatus().getPriority();
+                return (currentPriority != 4) ? currentPriority : (currentPriority - 3);
+            }));
             buildStatus = maxPrioProject.isPresent()
                     ? maxPrioProject.get().getBuildStatus() : buildStatus;
         }

--- a/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/Status.java
+++ b/backend/src/main/java/de/fraunhofer/iosb/maypadbackend/model/Status.java
@@ -22,7 +22,7 @@ public enum Status {
     /**
      * The process has not been completed yet.
      */
-    RUNNING(0),
+    RUNNING(4),
     /**
      * The process was canceled.
      */
@@ -61,6 +61,11 @@ public enum Status {
         return priority;
     }
 
+    /**
+     * Returns the name of the status.
+     *
+     * @return the name of the status.
+     */
     public String getName() {
         return this.toString().substring(0, 1).toUpperCase() + this.toString().substring(1);
     }


### PR DESCRIPTION
This PR adjusts the priorities for build status. New priorities: Running > Failed > Success. 
Projectgroups are an exception to this order and prefer Failed and Success over Running.